### PR TITLE
updated npm scripts for coverage, test & build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,18 @@
 sudo: false
 language: node_js
+node_js:
+  - '5'
 cache:
   directories:
     - node_modules
-notifications:
-  email: false
-node_js:
-  - '4'
-before_install:
-  - npm i -g npm@^3.0.0
 before_script:
   - npm prune
+notifications:
+  email: false
 script:
   - npm run validate
 after_success:
-  - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
-  - python travis_after_all.py
-  - 'export $(cat .to_export_back) &> /dev/null'
   - npm run report-coverage
 branches:
   only:
     - master
-

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "babel -d dist src",
     "check-coverage": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "lint": "eslint .",
-    "cover": "nyc --reporter=lcov --reporter=text --reporter=html npm test",
+    "cover": "nyc --reporter=lcov --reporter=text --reporter=html mocha src/**/*.test.js",
     "report-coverage": "cat ./coverage/lcov.info | node_modules/.bin/codecov",
     "test": "mocha `find src -name node_modules -prune -o -name '*.test.js' -print`",
     "watch:test": "npm run test -- -w",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "cover": "nyc --reporter=lcov --reporter=text --reporter=html mocha src/**/*.test.js",
     "report-coverage": "cat ./coverage/lcov.info | node_modules/.bin/codecov",
-    "test": "mocha `find src -name node_modules -prune -o -name '*.test.js' -print`",
+    "test": "mocha src/**/*.test.js",
     "watch:test": "npm run test -- -w",
     "release": "npm run build && with-package git commit -am pkg.version && with-package git tag pkg.version && git push && npm publish && git push --tags",
     "release:beta": "npm run release && npm run tag:beta",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "validate": "npm-run-all --parallel lint cover build test --sequential check-coverage",
-    "build": "babel -d dist src",
+    "build": "babel --ignore *.test.js -d dist src",
     "check-coverage": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "lint": "eslint .",
     "cover": "nyc --reporter=lcov --reporter=text --reporter=html mocha src/**/*.test.js",


### PR DESCRIPTION
* chore(coverage): use mocha instead of npm test
* chore(test): simplify test command
* chore(build): ignore *.test.js during transpilation