### PR TITLE
fix(output): Add hashDigestLength

### DIFF
--- a/src/properties/output/index.js
+++ b/src/properties/output/index.js
@@ -10,6 +10,7 @@ export default Joi.object({
   devtoolModuleFilenameTemplate: [notAbsolutePath, Joi.func()],
   devtoolFallbackModuleFilenameTemplate: [notAbsolutePath, Joi.func()],
   devtoolLineToLine: Joi.any(),
+  hashDigestLength: Joi.number(),
   hotUpdateChunkFilename: notAbsolutePath,
   hotUpdateMainFilename: notAbsolutePath,
   jsonpFunction: Joi.string(),

--- a/src/properties/output/index.test.js
+++ b/src/properties/output/index.test.js
@@ -37,6 +37,8 @@ const validModuleConfigs = [
   { crossOriginLoading: false },
   // #16
   { crossOriginLoading: 'anonymous' },
+  // #17
+  { hashDigestLength: 6 }, // undocumented
 
 ]
 


### PR DESCRIPTION
I just learned that this is a thing. Undocumented unfortunately. This is probably not the last time that we'll have to add undocumented properties.