### PR TITLE
test(deps): Add missing `glob` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-config-jonathanewerner": "1.0.1",
     "extract-text-webpack-plugin": "1.0.1",
     "ghooks": "1.2.0",
+    "glob": "7.0.3",
     "html-webpack-plugin": "2.15.0",
     "mocha": "2.4.5",
     "npm-run-all": "1.7.0",


### PR DESCRIPTION
I noticed this was missing when testing out Node 0.10.0 with the [failed build](https://travis-ci.org/jonathanewerner/webpack-validator/jobs/122553121) which uses `npm@2`. We use glob [here](https://github.com/jonathanewerner/webpack-validator/blob/1dd1d8ba6d824324bff6bdd2252a8b63717ee6c2/test/passing-configs/index.js)