### PR TITLE
Proposal new console output handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,9 +46,14 @@ const schema = Joi.object({
 
 
 // Easier consumability for require (default use case for non-transpiled webpack configs)
-module.exports = function validate(config, schema_ = schema) {
-  Joi.assert(config, schema_)
-  console.info(chalk.green('[webpack-validator] Config is valid.'))
-  return config
+module.exports = function validate(webpackConfig, schema_ = schema) {
+  const validationResult = Joi.validate(webpackConfig, schema_, { abortEarly: false })
+  if (validationResult.error) {
+    console.info(validationResult.error.annotate())
+    process.exit(1)
+  } else {
+    console.info(chalk.green('[webpack-validator] Config is valid.'))
+  }
+  return webpackConfig
 }
 module.exports.schema = schema


### PR DESCRIPTION
As discussed in https://github.com/jonathanewerner/webpack-validator/issues/54 I changed the behavior to use Joi.validate and instead of throwing an error I set the correct exit code. This way webpack-validator can still be used for CI environments and makes it easier for integrating with the cli.
With Joi.validate all keys get validated and we can show the complete validationResult. Also no callstack gets printed. I think this is a big plus. Today I showed a peer webpack-validator and as he saw the callstack he was very confused and thought this means there is a bug...
Caveat: we can no longer test the validate() function itself in its current form as it exits on validation errors. But I don't think that's a big deal as validate only calls Joi and does the console output. And with a bit of refactoring most of its logic can be tested again...
ATM lots of tests are broken as they expect thrown errors. I didn't want to put effort in fixing tests before I know you like my approach.

How do you think about this change @jonathanewerner @kentcdodds 